### PR TITLE
Release v2.0.1

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,6 +29,19 @@ version-resolver:
       - 'patch'
   default: patch
 autolabeler:
+  # --- version-resolver 用のラベル（semver 自動判定） ---
+  - label: major
+    title:
+      - '/^\w+(\(.+\))?!:/' # 例: feat!:, fix(scope)!: のような破壊的変更
+    body:
+      - '/BREAKING[ -]CHANGE/'
+  - label: minor
+    title:
+      - '/^feat(\(.+\))?:/'
+  - label: patch
+    title:
+      - '/^fix(\(.+\))?:/'
+  # --- categories 用のラベル（変更履歴の分類） ---
   - label: feature
     title:
       - '/^feat(ure)?:.+/'

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
       # - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint (oxlint)
+        run: npm run lint
+      - name: Format check (oxfmt)
+        run: npm run format:check
+      - name: Syntax check
+        run: node --check index.js && node --check message-maker.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grizzco-misskey-bot",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Misskeyにスケジュール更新を流すBotです。",
   "homepage": "https://github.com/sasagar/grizzco-misskey-bot#readme",
   "bugs": {


### PR DESCRIPTION
## v2.0.1

移管後（ikaskey）初リリース。新リリースフローの検証も兼ねる。

### 変更点（since v2.0.0）
- ci: lint/format CI ワークフロー追加（oxlint・oxfmt --check・node --check）
- ci: release-drafter に semver 自動ラベル（major/minor/patch）
- ci: build-image に `packages: write` 権限を明示（ikaskey org の ghcr push 用）
- chore: version 2.0.0 → 2.0.1

> アプリの挙動変更なし（CI/リリース基盤の整備）。