### PR TITLE
fix: ビッグラン/バチコン時のクラッシュ修正 (v3.0.1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ const salmonrun = async () => {
     }
     // ビッグランのシフトがあったら
     // 今がビッグランのシフトだったら
-    else if (Date(bigrun[0].start_time).getTime() / 1000 < getNowUnixTime()) {
+    else if (new Date(bigrun[0].start_time).getTime() / 1000 < getNowUnixTime()) {
       // 終了時刻を取得
       const end = new Date(bigrun[0].end_time);
       const endUnix = end.getTime() / 1000;
@@ -233,7 +233,7 @@ const salmonrun = async () => {
       // もし残りが2時間なら次のシフトのお知らせを追加
       if (restOfHours === 2) {
         // ビッグランよりも通常シフトが先なら次のシフトの情報を挟む
-        if (Date(regular[i + 1].start_time) < DataView(bigrun[0].start_time)) {
+        if (new Date(regular[i + 1].start_time) < new Date(bigrun[0].start_time)) {
           const next = new CoopMessageMaker(regular[i + 1], 40, false, true);
           const nextbigrun = new CoopMessageMaker(bigrun[0], 48, false, false, true, false, true);
 
@@ -273,7 +273,7 @@ const salmonrun = async () => {
     const teamcontest = teamcontestRes.results;
 
     if (teamcontest.length > 0) {
-      if (Date(teamcontest[0].start_time).getTime() / 1000 > nowUnix) {
+      if (new Date(teamcontest[0].start_time).getTime() / 1000 > nowUnix) {
         const nextteamcontest = new CoopMessageMaker(
           teamcontest[0],
           48,
@@ -287,7 +287,7 @@ const salmonrun = async () => {
       } else {
         // 残り時間を計算
         const restOfHours = Math.ceil(
-          (Date(teamcontest[0].end_time).getTime() / 1000 - nowUnix) / (60 * 60)
+          (new Date(teamcontest[0].end_time).getTime() / 1000 - nowUnix) / (60 * 60)
         );
 
         const nextteamcontest = new CoopMessageMaker(
@@ -330,12 +330,12 @@ const salmonrunextra = async () => {
   let msg = '';
   // レギュラーが時間内だったら、レギュラーを対象にする。それ以外はビッグラン扱い。
   if (
-    Date(regular[0].start_time).getTime() / 1000 < nowUnix &&
-    Date(regular[0].end_time).getTime() / 1000 > nowUnix
+    new Date(regular[0].start_time).getTime() / 1000 < nowUnix &&
+    new Date(regular[0].end_time).getTime() / 1000 > nowUnix
   ) {
     const now = new CoopMessageMaker(regular[0], 1, true);
     let nextShift;
-    if (bigrun.length === 0 || Date(regular[1].start_time) < Date(bigrun[0].start_time)) {
+    if (bigrun.length === 0 || new Date(regular[1].start_time) < new Date(bigrun[0].start_time)) {
       [, nextShift] = regular;
     } else {
       [nextShift] = bigrun;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grizzco-misskey-bot",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Splatoon 3 のサーモンラン/バチコン (coop) とバトル (regular/bankara/X/event) のスケジュール更新を Misskey に流す Bot。2アカウント運用に対応。",
   "homepage": "https://github.com/sasagar/grizzco-misskey-bot#readme",
   "bugs": {


### PR DESCRIPTION
## 概要

本番Botがサーモンランお知らせのたびにエラー投稿（「APIのデータに問題があるため…」）を繰り返していた不具合を修正します。

## 原因

`index.js` で `Date(...)` を **`new` なしで呼んでいる箇所が8つ**あり、現在時刻の文字列を返すため `.getTime()` が `TypeError` になっていました。さらに236行には `DataView(...)`（本来 `new Date(...)`）の誤りも混入。

```
TypeError: Date(...).getTime is not a function
    at salmonrun (file:///usr/src/app/index.js:175:41)
```

これらは **ビッグラン／バチコン（バイトチームコンテスト）開催中にのみ走る分岐**に集中しており、普段は実行されず潜在化していました（git履歴上 v2.0.0 以前からの既存バグ）。現在ビッグラン開催中のため毎正時に発症していました。

## 修正

- 8箇所を `new Date(...)` に統一、`DataView(...)` → `new Date(...)` に修正
- `package.json` を v3.0.1 に bump

## 確認

- `oxlint` / `oxfmt --check` / `node --check` パス
- Temporal整形（message-maker.js / battle-message-maker.js）は別途スモークテストで正常動作を確認（曜日・JST計算とも正確）。index.js の時刻演算は元から native Date でTemporal移行対象外
- message-maker.js / battle-message-maker.js には同種バグなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)