### PR TITLE
docs: 現行コードの JSDoc 整備と参照を ikaskey へ更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 .env
 .claude/
+
+# JSDoc 生成物（CI で生成・デプロイするため追跡しない）
+docs/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Grizzco Misskey-bot
 
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/sasagar/grizzco-misskey-bot/build-image.yml?label=Container%20Build&style=for-the-badge)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/ikaskey/grizzco-misskey-bot/build-image.yml?label=Container%20Build&style=for-the-badge)
 
-![GitHub package.json version (subfolder of monorepo)](https://img.shields.io/github/package-json/v/sasagar/grizzco-misskey-bot?style=for-the-badge) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/sasagar/grizzco-misskey-bot?include_prereleases&style=for-the-badge)
+![GitHub package.json version (subfolder of monorepo)](https://img.shields.io/github/package-json/v/ikaskey/grizzco-misskey-bot?style=for-the-badge) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/ikaskey/grizzco-misskey-bot?include_prereleases&style=for-the-badge)
 
 ## What
 
@@ -20,7 +20,7 @@ At any directory that specified, make `compose.yml` like below.
 ```yaml
 services:
   grizzco-misskey-bot:
-    image: ghcr.io/sasagar/grizzco-misskey-bot
+    image: ghcr.io/ikaskey/grizzco-misskey-bot
     restart: always
     volumes:
       - .env:/usr/src/app/.env:ro

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "grizzco-misskey-bot",
   "version": "3.0.2",
   "description": "Splatoon 3 のサーモンラン/バチコン (coop) とバトル (regular/bankara/X/event) のスケジュール更新を Misskey に流す Bot。2アカウント運用に対応。",
-  "homepage": "https://github.com/sasagar/grizzco-misskey-bot#readme",
+  "homepage": "https://github.com/ikaskey/grizzco-misskey-bot#readme",
   "bugs": {
-    "url": "https://github.com/sasagar/grizzco-misskey-bot/issues"
+    "url": "https://github.com/ikaskey/grizzco-misskey-bot/issues"
   },
   "license": "GPL-3.0",
   "author": "@sasagar",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sasagar/grizzco-misskey-bot.git"
+    "url": "git+https://github.com/ikaskey/grizzco-misskey-bot.git"
   },
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## 概要

現行プログラム（`battle-message-maker.js` / `BattleMessageMaker` を含む v3.0.x）の JSDoc 生成・自動デプロイを整え、ドキュメントに残る `sasagar` 参照を `ikaskey` へ更新します。

## 調査でわかったこと

- 現行コードは index.js / message-maker.js / battle-message-maker.js とも **JSDoc 完備**（クラス・関数・スケジューラ・定数すべて `@since`/`@param`/`@returns` 付き）。
- `jsdoc.json` は `source.include: ["./"]` + recurse のため、**`battle-message-maker.js` も生成対象**。
- `github-pages-jsdoc.yml` が **main push 時に生成 → Pages デプロイ**しており、**自動化は既に稼働**。ライブサイトにも `BattleMessageMaker.html` が存在（200）。

→ つまり生成・自動化は達成済みだったため、本 PR は残る品質・整合性の修正に絞っています。

## 変更

- **README**: バッジ URL と compose 例の `image` を `sasagar` → `ikaskey` に修正（compose 例を実イメージ `ghcr.io/ikaskey/grizzco-misskey-bot` に一致）。README は JSDoc Home に出るため生成 docs も正しくなる。
- **package.json**: `homepage` / `bugs.url` / `repository.url` を `ikaskey` へ（`author` は `@sasagar` のまま）。
- **.gitignore**: JSDoc 生成物 `docs/` を追加（CI 生成・Pages デプロイのため追跡しない）。

## 確認

- ワークフロー同等コマンド `jsdoc -c ./jsdoc.json -R ./README.md` で生成 → Home が `ikaskey` 参照×4、`BattleMessageMaker.html` 生成を確認
- `oxlint` / `oxfmt --check` パス
- マージで `github-pages-jsdoc.yml` が走り、最新 docs（ikaskey 参照・Battle ページ）が再デプロイされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)