### PR TITLE
refactor: 重複コードを共通化 (#26, #27, #28)

### DIFF
--- a/battle-message-maker.js
+++ b/battle-message-maker.js
@@ -1,30 +1,7 @@
 import * as fs from 'node:fs';
 
-// 日本語の曜日ラベル。Temporal.ZonedDateTime.dayOfWeek は 1=月曜 ... 7=日曜。
-/**
- * Japanese short weekday labels indexed by Temporal dayOfWeek (1-7).
- * @since v3.0.0
- * @type {string[]}
- */
-const WEEKDAYS_JA = ['月', '火', '水', '木', '金', '土', '日'];
-
-/**
- * Format an ISO datetime string into a JST string like "5月25日(月) 10:00".
- * Uses the built-in Temporal API, matching message-maker.js so battle and coop
- * messages share an identical date format without an external date library.
- * @since v3.0.0
- * @param {string} isoString - ISO 8601 datetime string.
- * @returns {string} - Formatted JST datetime, e.g. "5月25日(月) 10:00".
- */
-const formatJst = (isoString) => {
-  const zdt = Temporal.Instant.fromEpochMilliseconds(Date.parse(isoString)).toZonedDateTimeISO(
-    'Asia/Tokyo'
-  );
-  const weekday = WEEKDAYS_JA[zdt.dayOfWeek - 1];
-  const hour = String(zdt.hour).padStart(2, '0');
-  const minute = String(zdt.minute).padStart(2, '0');
-  return `${zdt.month}月${zdt.day}日(${weekday}) ${hour}:${minute}`;
-};
+// eslint-disable-next-line import/extensions
+import { formatJst } from './date-format.js';
 
 /**
  * Class to generate battle (Regular/Bankara/X/Event) message.

--- a/date-format.js
+++ b/date-format.js
@@ -1,0 +1,26 @@
+// 日本語の曜日ラベル。Temporal.ZonedDateTime.dayOfWeek は 1=月曜 ... 7=日曜。
+/**
+ * Japanese short weekday labels indexed by Temporal dayOfWeek (1-7).
+ * @since v3.0.3
+ * @type {string[]}
+ */
+const WEEKDAYS_JA = ['月', '火', '水', '木', '金', '土', '日'];
+
+/**
+ * Format an ISO datetime string into a JST string like "5月25日(月) 10:00".
+ * Uses the built-in Temporal API so coop (message-maker) and battle
+ * (battle-message-maker) messages share an identical date format without an
+ * external date library.
+ * @since v3.0.3
+ * @param {string} isoString - ISO 8601 datetime string.
+ * @returns {string} - Formatted JST datetime, e.g. "5月25日(月) 10:00".
+ */
+export const formatJst = (isoString) => {
+  const zdt = Temporal.Instant.fromEpochMilliseconds(Date.parse(isoString)).toZonedDateTimeISO(
+    'Asia/Tokyo'
+  );
+  const weekday = WEEKDAYS_JA[zdt.dayOfWeek - 1];
+  const hour = String(zdt.hour).padStart(2, '0');
+  const minute = String(zdt.minute).padStart(2, '0');
+  return `${zdt.month}月${zdt.day}日(${weekday}) ${hour}:${minute}`;
+};

--- a/index.js
+++ b/index.js
@@ -110,6 +110,26 @@ const sendMessage = async (client, msg, visibility = null, cw = null, replyId = 
 // COOP (サーモンラン + バチコン) -- posts via grizzcoClient
 // =============================================================================
 
+// 残り2時間のシフトに対し、終了1時間前の追加お知らせを予約する共通処理。
+/**
+ * Schedule the extra "last hour" Salmon Run note, fired 1 hour before the
+ * given shift end time. Extracted from the repeated block in salmonrun
+ * (refs #26, #27).
+ * @since v3.0.3
+ * @param {string} endTime - ISO end_time of the reference shift.
+ * @returns {void}
+ */
+const scheduleSalmonExtraNote = (endTime) => {
+  // 一回だけ1時間おきにしたいので、追加する
+  const extraNoteDate = (new Date(endTime).getTime() / 1000 - 60 * 60) * 1000;
+  console.log(extraNoteDate.toLocaleString());
+  // eslint-disable-next-line no-use-before-define
+  salmonjobExtra = schedule.scheduleJob(extraNoteDate, () => {
+    salmonrunextra();
+  });
+  console.log(`set: salmonrunextra at ${extraNoteDate}`);
+};
+
 // サーモンランルール
 /**
  * Make and send Salmon Run / バチコン message to Misskey (grizzco account).
@@ -157,15 +177,7 @@ const salmonrun = async () => {
         msg += '\n---\n';
         msg += next.maker();
 
-        // 一回だけ1時間おきにしたいので、追加する
-        const extraDate = new Date(regular[i].end_time);
-        const extraNoteDate = (extraDate.getTime() / 1000 - 60 * 60) * 1000;
-        console.log(extraNoteDate.toLocaleString());
-        // eslint-disable-next-line no-use-before-define
-        salmonjobExtra = schedule.scheduleJob(extraNoteDate, () => {
-          salmonrunextra();
-        });
-        console.log(`set: salmonrunextra at ${extraNoteDate}`);
+        scheduleSalmonExtraNote(regular[i].end_time);
       }
       console.log(msg);
       sendMessage(grizzcoClient, msg);
@@ -195,15 +207,7 @@ const salmonrun = async () => {
         msg += '\n---\n';
         msg += next.maker();
 
-        // 一回だけ1時間おきにしたいので、追加する
-        const extraDate = new Date(regular[0].end_time);
-        const extraNoteDate = (extraDate.getTime() / 1000 - 60 * 60) * 1000;
-        console.log(extraNoteDate.toLocaleString());
-        // eslint-disable-next-line no-use-before-define
-        salmonjobExtra = schedule.scheduleJob(extraNoteDate, () => {
-          salmonrunextra();
-        });
-        console.log(`set: salmonrunextra at ${extraNoteDate}`);
+        scheduleSalmonExtraNote(regular[0].end_time);
       }
       sendMessage(grizzcoClient, msg);
     }
@@ -249,15 +253,7 @@ const salmonrun = async () => {
           msg += nextbigrun.maker();
         }
 
-        // 一回だけ1時間おきにしたいので、追加する
-        const extraDate = new Date(regular[0].end_time);
-        const extraNoteDate = (extraDate.getTime() / 1000 - 60 * 60) * 1000;
-        console.log(extraNoteDate.toLocaleString());
-        // eslint-disable-next-line no-use-before-define
-        salmonjobExtra = schedule.scheduleJob(extraNoteDate, () => {
-          salmonrunextra();
-        });
-        console.log(`set: salmonrunextra at ${extraNoteDate}`);
+        scheduleSalmonExtraNote(regular[0].end_time);
       }
       // ビッグランの情報を付ける
       else {

--- a/message-maker.js
+++ b/message-maker.js
@@ -1,29 +1,7 @@
 import * as fs from 'node:fs';
 
-// 日本語の曜日ラベル。Temporal.ZonedDateTime.dayOfWeek は 1=月曜 ... 7=日曜。
-/**
- * Japanese short weekday labels indexed by Temporal dayOfWeek (1-7).
- * @since v2.0.0
- * @type {string[]}
- */
-const WEEKDAYS_JA = ['月', '火', '水', '木', '金', '土', '日'];
-
-/**
- * Format an ISO datetime string into a JST string like "5月25日(月) 10:00".
- * Uses the built-in Temporal API, so no external date library is required.
- * @since v2.0.0
- * @param {string} isoString - ISO 8601 datetime string.
- * @returns {string} - Formatted JST datetime, e.g. "5月25日(月) 10:00".
- */
-const formatJst = (isoString) => {
-  const zdt = Temporal.Instant.fromEpochMilliseconds(Date.parse(isoString)).toZonedDateTimeISO(
-    'Asia/Tokyo'
-  );
-  const weekday = WEEKDAYS_JA[zdt.dayOfWeek - 1];
-  const hour = String(zdt.hour).padStart(2, '0');
-  const minute = String(zdt.minute).padStart(2, '0');
-  return `${zdt.month}月${zdt.day}日(${weekday}) ${hour}:${minute}`;
-};
+// eslint-disable-next-line import/extensions
+import { formatJst } from './date-format.js';
 
 // ランダム支給ブキは API の name が金?・緑?どちらも「ランダム」で区別できないため、
 // 画像の SplatNet3 リソース ID（ハッシュ）で判別する。ハッシュは av5ja SDK 準拠で固定。


### PR DESCRIPTION
## 概要

CodeClimate の "similar-code" 指摘 Issue（#26 / #27 = index.js、#28 = message-maker.js）に対応し、現行コードに残る実重複を解消します。**挙動は変えません**（behavior-preserving）。

元の CodeClimate リンクは旧 `sasagar` のもので無効、行参照も v2/v3 の大改修で陳腐化していますが、現行コードに残っていた実重複を実際に潰します。

## 変更

- **`WEEKDAYS_JA` / `formatJst` の二重定義を解消**：message-maker.js と battle-message-maker.js にバイト同一で重複していた（v3.0.0 統合時に発生）→ 共通モジュール **`date-format.js`** に抽出し両者で import。(#28 関連)
- **`salmonrun` の反復ブロックを抽出**：index.js で「終了1時間前の追加お知らせ予約」ブロックが3箇所反復 → **`scheduleSalmonExtraNote(endTime)`** ヘルパーに集約。(#26 / #27 関連)

## 確認

- `oxlint` / `oxfmt --check` / `node --check` パス
- 実APIスモークテストで coop（金?ランダム判定）・coop next・battle の出力が **refactor 前と完全一致**
- 共有 `formatJst` が両 message-maker で正しく動作

## デプロイ方針

挙動を変えない内部リファクタのため、**本番再デプロイは行いません**（再起動通知の二重投稿を避けるため）。本番は機能的に同一の v3.0.2 のまま、本変更は次回の機能リリースに同梱されます。

Closes #26
Closes #27
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)