### PR TITLE
chore: release v3.0.3（最新コードを本番反映）

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grizzco-misskey-bot",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Splatoon 3 のサーモンラン/バチコン (coop) とバトル (regular/bankara/X/event) のスケジュール更新を Misskey に流す Bot。2アカウント運用に対応。",
   "homepage": "https://github.com/ikaskey/grizzco-misskey-bot#readme",
   "bugs": {


### PR DESCRIPTION
## 概要

PR #45（README/メタ・docs整備）・#46（重複コード共通化リファクタ）を含む最新コードを本番 Bot に反映するためのリリースです。**挙動変更はありません**。

## 含まれる変更
- v3.0.1: ビッグラン/バチコン時のクラッシュ修正（`new` 抜けの `Date()`）
- v3.0.2: ランダム支給ブキの金?/緑?判別（画像ハッシュ）
- #45: README/package.json の ikaskey 参照化、`docs/` gitignore
- #46: `WEEKDAYS_JA`/`formatJst` を `date-format.js` に共通化、`scheduleSalmonExtraNote` 抽出

## 確認
- `oxlint` / `oxfmt --check` / `node --check` パス済み（各 PR で確認済）
- 実APIスモークテストで出力不変を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)